### PR TITLE
Fixed 2 issues of type: PYTHON_E225 throughout 2 files in repo.

### DIFF
--- a/baseline/train.py
+++ b/baseline/train.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
     torch.manual_seed(args.seed)
     if torch.cuda.is_available(): torch.cuda.manual_seed_all(args.seed)
     random.seed(args.seed)
-    torch.backends.cudnn.deterministic=True
+    torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = True
     from DRL.ddpg import DDPG
     from DRL.multi import fastenv

--- a/baseline/utils/tensorboard.py
+++ b/baseline/utils/tensorboard.py
@@ -25,5 +25,5 @@ class TensorBoard(object):
         self.summary_writer.add_summary(summary, global_step=step)
 
     def add_scalar(self, tag, value, step):
-        summary= Summary(value=[Summary.Value(tag=tag, simple_value=value)])
+        summary = Summary(value=[Summary.Value(tag=tag, simple_value=value)])
         self.summary_writer.add_summary(summary, global_step=step)


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.