### PR TITLE
import numpy as np for access to np.sqrt() on line 17

### DIFF
--- a/baseline/DRL/actor.py
+++ b/baseline/DRL/actor.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/hzwer/LearningToPaint on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./baseline/DRL/actor.py:15:9: F821 undefined name 'init'
        init.xavier_uniform(m.weight, gain=np.sqrt(2))
        ^
./baseline/DRL/actor.py:15:44: F821 undefined name 'np'
        init.xavier_uniform(m.weight, gain=np.sqrt(2))
                                           ^
./baseline/DRL/actor.py:16:9: F821 undefined name 'init'
        init.constant(m.bias, 0)
        ^
3     F821 undefined name 'init'
3
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree